### PR TITLE
Combined dev scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "postinstall": "electron-builder install-app-deps",
-    "electron:dev": "concurrently \"BROWSER=none yarn start\" \"wait-on http://localhost:3000 && tsc -p electron -w\" \"wait-on http://localhost:3000 && tsc -p electron && electron .\"",
-    "electron:windev": "concurrently \"SET BROWSER=none && yarn start\" \"wait-on http://localhost:3000 && tsc -p electron -w\" \"wait-on http://localhost:3000 && tsc -p electron && electron .\"",
+    "electron:dev": "concurrently \"cross-env BROWSER=none yarn start\" \"wait-on http://localhost:3000 && tsc -p electron -w\" \"wait-on http://localhost:3000 && tsc -p electron && electron .\"",
     "electron:build": "yarn build && tsc -p electron && electron-builder",
     "eject": "react-scripts eject"
   },
@@ -58,6 +57,7 @@
     "concurrently": "^6.0.0",
     "electron": "^12.0.1",
     "electron-builder": "^22.10.5",
-    "wait-on": "^5.3.0"
+    "wait-on": "^5.3.0",
+    "cross-env": "^7.0.3"
   }
 }


### PR DESCRIPTION
Implements the changes discussed in  #16 

Adds cross-env as a dev dependency.
Uses cross-env to improve compatibility with non-standard installations of windows (such as those using Bash On Windows).
Condenses the "electron:windev" and "electron:dev" into a single "electron:dev" script.