### PR TITLE
Improved compatibility on windows

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -27,7 +27,12 @@ function createWindow() {
   if (isDev) {
     // 'node_modules/.bin/electronPath'
     require('electron-reload')(__dirname, {
-      electron: path.join(__dirname, '..', '..', 'node_modules', '.bin', 'electron'),
+      electron: path.join(__dirname,
+        '..',
+        '..',
+        'node_modules',
+        '.bin',
+        'electron' + (process.platform === "win32" ? ".cmd" : "")),
       forceHardReset: true,
       hardResetMethod: 'exit'
     });


### PR DESCRIPTION
Implements the fix given in #9 

Adds a check that changes the electron-reload electron path if on a windows system.
Changed the formatting of the multiple argument path.join().