### PR TITLE
Fix issue where electron doesn't open with electron:dev task

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ app.on('activate', () => {
 ```json
   "scripts": {
     "postinstall": "electron-builder install-app-deps",
-    "electron:dev": "concurrently \"cross-env BROWSER=none yarn start\" \"wait-on http://localhost:3000 && tsc -p electron -w\" \"wait-on http://localhost:3000 && tsc -p electron && electron .\"",
+    "electron:dev": "concurrently \"cross-env BROWSER=none yarn start\" \"wait-on http://127.0.0.1:3000 && tsc -p electron -w\" \"wait-on http://127.0.0.1:3000 && tsc -p electron && electron .\"",
     "electron:build": "yarn build && tsc -p electron && electron-builder",
 ```
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "postinstall": "electron-builder install-app-deps",
-    "electron:dev": "concurrently \"cross-env BROWSER=none yarn start\" \"wait-on http://localhost:3000 && tsc -p electron -w\" \"wait-on http://localhost:3000 && tsc -p electron && electron .\"",
+    "electron:dev": "concurrently \"cross-env BROWSER=none yarn start\" \"wait-on http://127.0.0.1:3000 && tsc -p electron -w\" \"wait-on http://127.0.0.1:3000 && tsc -p electron && electron .\"",
     "electron:build": "yarn build && tsc -p electron && electron-builder",
     "eject": "react-scripts eject"
   },


### PR DESCRIPTION
On Windows (probably other systems too) with Node 17+, running `yarn electron:dev` fails to open electron. This happens because the "wait-on http://localhost:3000" step of the script never succeeds.

`react-scripts start` launches a dev server on IPv4 (because https://github.com/facebook/create-react-app/blob/d960b9e38c062584ff6cfb1a70e1512509a966e7/packages/react-scripts/scripts/start.js#L56 specifies that it listens on "0.0.0.0", an IPv4 address). `wait-on http://localhost:3000` tries to connect over IPv6 and fails. By changing the command to `wait-on http://127.0.0.1:3000`, wait-on will make an IPv4 request and succeed, allowing electron to open.

Here's a related thread about other people running into this issue with wait-on and working around it similarly: https://github.com/jeffbski/wait-on/issues/109